### PR TITLE
add umd ponyfill to webpack

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,6 @@
 const path = require('path');
 
-module.exports = {
+module.exports = [{
   mode: 'production',
   entry: ['./src/index.js', './polyfill.js'],
   output: {
@@ -10,4 +10,14 @@ module.exports = {
     libraryTarget: 'umd',
     globalObject: 'this'
   }
-};
+}, {
+  mode: 'production',
+  entry: ['./src/index.js'],
+  output: {
+    filename: 'yetch-ponyfill.js',
+    path: path.resolve(__dirname, 'dist'),
+    library: 'Yetch',
+    libraryTarget: 'umd',
+    globalObject: 'this'
+  }
+}];


### PR DESCRIPTION
Hi, I'm working on a pretender which is a browser-based API mock server and need a umd ponyfill to introduce a `Yetch` global . So that I can import directly from node_module as
https://github.com/pretenderjs/pretender/pull/230/commits/26b42fc56731667be4dabfbdeb8de65fb1539c2a#diff-a2a3b7b0c9c3b4b93b4aebf4e3ec3cfbL24

This could be done by adding another webpack config omitting ./polyfill.js 